### PR TITLE
Use the correct keys for aisle information

### DIFF
--- a/src/components/Items.js
+++ b/src/components/Items.js
@@ -45,7 +45,7 @@ export class Items extends Component {
           onClick={() => this.onClickHandler(item.id)}
         >
           {item.name}
-          {item.aisleLocation}
+          {item.aisleLocation && item.aisleLocation.aisleNo}
         </li>
       );
     });


### PR DESCRIPTION
This goes hand-in-hand with https://github.com/thinkful-ei25/hiphip-server/pull/23 as it uses the correct keys for aisle numbers. Without this fix, the client just crashes.