### PR TITLE
Make CreateShoppingList routeable again

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,8 +12,8 @@ class App extends Component {
         <Route exact path="/" component={LoginPage} />
         <Route exact path="/register" component={RegistrationPage} />
         <Route exact path="/lists" component={Lists} />
-        <Route exact path="/lists/:listId" component={Items} />
         <Route exact path="/lists/create" component={CreateShoppingList} />
+        <Route exact path="/lists/:listId" component={Items} />
       </Switch>
     );
   }


### PR DESCRIPTION
This was due to the /lists/:listId capturing the /lists/create url.