### PR TITLE
Fix/flash stale search

### DIFF
--- a/src/components/CreateShoppingListForm/CreateShoppingListForm.js
+++ b/src/components/CreateShoppingListForm/CreateShoppingListForm.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import StoreSearch from '../StoreSearch';
 
 import { createList } from '../../actions/shoppingLists';
-import { clearCurrentStore } from '../../actions/yelpAPI';
+import { clearCurrentStore, clearStores } from '../../actions/yelpAPI';
 
 export class CreateShoppingListForm extends React.Component {
   onSubmit(event) {
@@ -28,6 +28,7 @@ export class CreateShoppingListForm extends React.Component {
   newStore() {
     const { dispatch } = this.props;
     dispatch(clearCurrentStore());
+    dispatch(clearStores());
   }
 
   render() {

--- a/src/components/Items/Items.css
+++ b/src/components/Items/Items.css
@@ -1,3 +1,7 @@
+.loading-container {
+  text-align: center;
+}
+
 .Items .shoppingList {
   margin-top: 10px;
   display: grid;

--- a/src/components/Items/Items.js
+++ b/src/components/Items/Items.js
@@ -12,8 +12,10 @@ import {
   editListName,
   changeListName,
 } from '../../actions/items';
+
 import NavBar from '../nav-bar';
 import AddAisle from '../AddAisle';
+import LoadingSpinner from '../LoadingSpinner';
 import authRequired from '../authRequired';
 import { compareAisle, sortAisle } from './utils';
 
@@ -72,7 +74,11 @@ export class Items extends Component {
     } = this.props;
 
     if (loading) {
-      return <div>Loading...</div>;
+      return (
+        <div className="loading-container">
+          <LoadingSpinner />
+        </div>
+      );
     }
 
     let sortedItems = items.slice();

--- a/src/components/Lists/Lists.js
+++ b/src/components/Lists/Lists.js
@@ -8,7 +8,11 @@ import NavBar from '../nav-bar';
 import CreateShoppingList from '../CreateShoppingList';
 
 import { getLists, clearError } from '../../actions/shoppingLists';
-import { clearCurrentStore, setUserLocation } from '../../actions/yelpAPI';
+import {
+  clearCurrentStore,
+  setUserLocation,
+  clearStores,
+} from '../../actions/yelpAPI';
 import './Lists.css';
 export class Lists extends Component {
   componentDidMount() {
@@ -29,6 +33,7 @@ export class Lists extends Component {
   closeOut() {
     this.props.dispatch(clearError());
     this.props.dispatch(clearCurrentStore());
+    this.props.dispatch(clearStores());
   }
 
   render() {

--- a/src/reducers/yelpAPI.js
+++ b/src/reducers/yelpAPI.js
@@ -37,18 +37,15 @@ export default function storeReducer(state = initialState, action) {
         ...state,
         userLocation: null,
         error: action.error,
-        // loading: false,
       };
     case USER_LOCATION_REQUEST:
       return {
         ...state,
-        // loading: true,
         error: null,
       };
     case USER_LOCATION_SUCCESS:
       return {
         ...state,
-        // loading: false,
         userLocation: action.location,
       };
     default:


### PR DESCRIPTION
Took away the stale search results from closing and reopening the add-list modal by dispatching clearStores() when the close button is clicked