### PR TITLE
Prevent flash of unchecking when sending aisle info

### DIFF
--- a/src/reducers/items.js
+++ b/src/reducers/items.js
@@ -101,7 +101,7 @@ export default function reducer(state = initialState, action) {
             return item;
           }
           state.patchItemReq = originalItem;
-          return updatedItem;
+          return { ...item, ...updatedItem };
         }),
       };
     }


### PR DESCRIPTION
This was caused by not merging the original item with it's new aisle update in
the reducer.